### PR TITLE
feat: add --hide option to CLI for filtering variable output

### DIFF
--- a/docs/pages/docs/quint.md
+++ b/docs/pages/docs/quint.md
@@ -242,6 +242,8 @@ Options:
                                                       [string] [default: "true"]
   --witnesses    space separated list of witnesses to report on (counting for
                  how many traces the witness is true)      [array] [default: []]
+  --hide         space separated list of variable names to hide from the terminal
+                 output (does not affect ITF output)       [array] [default: []]
   --seed         random seed to use for non-deterministic choice        [string]
   --verbosity    control how much output is produced (0 to 5)
                                                            [number] [default: 2]

--- a/quint/src/cli.ts
+++ b/quint/src/cli.ts
@@ -276,6 +276,11 @@ const runCmd = {
         type: 'array',
         default: [],
       })
+      .option('hide', {
+        desc: 'space separated list of variable names to hide from the terminal output (does not affect ITF output)',
+        type: 'array',
+        default: [],
+      })
       .option('seed', {
         desc: 'random seed to use for non-deterministic choice',
         type: 'string',

--- a/quint/src/cliCommands.ts
+++ b/quint/src/cliCommands.ts
@@ -475,14 +475,14 @@ export async function runTests(prev: TypecheckedStage): Promise<CLIProcedure<Tes
 }
 
 // Print a counterexample if the appropriate verbosity is set
-function maybePrintCounterExample(verbosityLevel: number, states: QuintEx[], frames: ExecutionFrame[] = []) {
+function maybePrintCounterExample(verbosityLevel: number, states: QuintEx[], frames: ExecutionFrame[] = [], hideVars: string[] = []) {
   if (verbosity.hasStateOutput(verbosityLevel)) {
     console.log(chalk.gray('An example execution:\n'))
     const myConsole = {
       width: terminalWidth(),
       out: (s: string) => process.stdout.write(s),
     }
-    printTrace(myConsole, states, frames)
+    printTrace(myConsole, states, frames, hideVars)
   }
 }
 
@@ -534,6 +534,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
     rng,
     verbosity: verbosityLevel,
     storeMetadata: prev.args.mbt,
+    hideVars: prev.args.hide || [],
     numberOfTraces: prev.args.nTraces,
     onTrace: (index: number, status: string, vars: string[], states: QuintEx[]) => {
       const itfFile: string | undefined = prev.args.outItf
@@ -663,7 +664,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
       })
 
     case 'ok':
-      maybePrintCounterExample(verbosityLevel, states, frames)
+      maybePrintCounterExample(verbosityLevel, states, frames, prev.args.hide || [])
       if (verbosity.hasResults(verbosityLevel)) {
         console.log(chalk.green('[ok]') + ' No violation found ' + chalk.gray(`(${elapsedMs}ms).`))
         if (verbosity.hasHints(verbosityLevel)) {
@@ -680,7 +681,7 @@ export async function runSimulator(prev: TypecheckedStage): Promise<CLIProcedure
       })
 
     case 'violation':
-      maybePrintCounterExample(verbosityLevel, states, frames)
+      maybePrintCounterExample(verbosityLevel, states, frames, prev.args.hide || [])
       if (verbosity.hasResults(verbosityLevel)) {
         console.log(chalk.red(`[violation]`) + ' Found an issue ' + chalk.gray(`(${elapsedMs}ms).`))
 
@@ -913,7 +914,7 @@ export async function verifySpec(prev: CompiledStage): Promise<CLIProcedure<Trac
         const status = trace !== undefined ? 'violation' : 'failure'
         if (trace !== undefined) {
           // Always print the conterexample, unless the output is being directed to one of the outfiles
-          maybePrintCounterExample(verbosityLevel, trace)
+          maybePrintCounterExample(verbosityLevel, trace, [], prev.args.hide || [])
 
           if (verbosity.hasResults(verbosityLevel)) {
             console.log(chalk.red(`[${status}]`) + ' Found an issue ' + chalk.gray(`(${elapsedMs}ms).`))

--- a/quint/src/simulation.ts
+++ b/quint/src/simulation.ts
@@ -25,6 +25,7 @@ export interface SimulatorOptions {
   rng: Rng
   verbosity: number
   storeMetadata: boolean
+  hideVars: string[]
   onTrace(index: number, status: string, vars: string[], states: QuintEx[]): void
 }
 


### PR DESCRIPTION
Introduced a new command-line option `--hide` that allows users to specify a list of variable names to be excluded from terminal output. This change enhances the usability of the CLI by providing more control over the displayed information without affecting ITF output. Updated relevant functions to support this feature.

<!-- Please ensure that your PR includes the following, as needed -->

- [ ] Tests added for any new code
- [ ] Documentation added for any new functionality
- [ ] Entries added to the respective `CHANGELOG.md` for any new functionality
- [ ] Feature table on [`README.md`](../README.md#roadmap) updated for any listed functionality

<!--
Some common CI checks and how to fix them (if failing):
- The formatting in all files is consistent with the project's style.
   - Run `npm run format` to automatically format all files.
- The `examples/README.md` file contains all Quint files in `examples/`
  and correctly lists their ability to go through pipeline stages.
   - Run `make examples` to automatically regenerate this file locally.
- The assets in `quint/testFixture` and `doc/builtin.md` are consistent.
   - Run `npm run generate` to automatically update these files locally.
-->
